### PR TITLE
vendor/overlay: Fix blue accent color for dark mode

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values/colors.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/colors.xml
@@ -15,9 +15,9 @@
     limitations under the License.
 -->
 <resources>
-    <color name="accent_device_default_700">#167C80</color>
-    <color name="accent_device_default_dark">#167C80</color>
-    <color name="accent_device_default_light">#167C80</color>
+    <color name="accent_device_default_700">#ff1a73e8</color>
+    <color name="accent_device_default_dark">#ff8ab4f8</color>
+    <color name="accent_device_default_light">#ff1a73e8</color>
     <color name="material_deep_teal_200">#167C80</color>
     <color name="material_deep_teal_500">#167C80</color>
 

--- a/overlay/common/frameworks/base/core/res/res/values/colors_device_defaults.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/colors_device_defaults.xml
@@ -27,7 +27,7 @@
     <color name="tertiary_device_default_settings">#ff616161</color>
     <color name="quaternary_device_default_settings">#ff9e9e9e</color>
     <color name="accent_device_default_light">#ff1a73e8</color>
-    <color name="accent_device_default_dark">#ff2581df</color>
+    <color name="accent_device_default_dark">#ff8ab4f8</color>
     <color name="error_color_device_default_dark">#ffe25142</color>
     <color name="error_color_device_default_light">#ffd93025</color>
 


### PR DESCRIPTION
* Actually, blue accent color looks same for light/dark mode. So let's use Pixel's style for this accent in dark mode.